### PR TITLE
Claude Code plugin + --version + install.sh checksum-safety (v4.1.0), reconciled onto v4.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "openfoia",
+  "owner": {
+    "name": "Jordan Coin Jackson"
+  },
+  "metadata": {
+    "description": "Claude Code plugin for OpenFOIA — local-first FOIA automation and AI document analysis for journalists and researchers."
+  },
+  "plugins": [
+    {
+      "name": "openfoia",
+      "source": "./plugin",
+      "description": "Help journalists and researchers run FOIA investigations using the openfoia CLI. Ships a skill covering the full records-search → download → OCR → extract → crossref → graph loop plus slash commands for each phase."
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ Thumbs.db
 # Logs
 *.log
 logs/
+
+# Generated benchmark artifact (tests/benchmark_extraction.py)
+test_graph.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,191 @@
+# Changelog
+
+All notable changes to OpenFOIA are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries before 4.0.0 are backfilled from git history and are summaries, not
+exhaustive lists.
+
+## [4.1.0] - 2026-08-11
+
+Additive release on top of the 4.0.0 security hardening. No security
+regressions: the 4.0.0 network egress choke point, graph escaping, CDN
+removal, and fail-closed installer verification are all preserved.
+
+### Added
+
+- A Claude Code plugin (`plugin/`) — an `openfoia` skill plus four slash
+  commands (`/foia-install`, `/foia-search`, `/foia-investigate`,
+  `/foia-graph`). Install with
+  `/plugin marketplace add JordanCoin/openfoia` then
+  `/plugin install openfoia@openfoia`. Every documented `openfoia ...`
+  invocation is validated against the live 4.0.0 command tree, including the
+  new `egress-status` command.
+- `openfoia --version` (also `-V`), sourced from `openfoia.__version__`.
+- `openfoia analyze graph --no-text` — export the entity graph without
+  embedding document bodies. When text *is* included, the command now warns
+  that the export is plaintext and lives outside the encrypted database.
+- `CHANGELOG.md` (this file) and a web-UI section in `docs/AIRGAP.md`.
+
+### Fixed
+
+- **Installer could mistake a checksum file for the binary.** `install.sh`
+  matched release assets by unanchored substring, so `pdf-extract-<platform>`
+  also matched `pdf-extract-<platform>.sha256`. With no guaranteed asset
+  ordering, the installer could have downloaded the checksum file and installed
+  it as the extractor. The match is now anchored to the exact asset name. This
+  sits on top of 4.0.0's fail-closed checksum verification.
+- The benchmark's graph writer (`tests/benchmark_extraction.py`) spliced raw
+  JSON into an inline `<script>` via `JSON.parse('...')`, which both broke on
+  the apostrophes and quotes FOIA data is full of (`O'Brien`,
+  `Prince George's County`) and re-opened the same injection vector 4.0.0
+  closed in the main renderer. It now uses `escape_json_for_script`.
+
+### Internal
+
+- `pyyaml` added to the `dev` extra — `tests/test_plugin.py` parses plugin
+  frontmatter and imported it without it being declared.
+- `tests/test_plugin.py` resolves every documented plugin invocation against
+  the real command tree, and fails if a top-level command is undocumented in
+  the skill.
+- `tests/test_security.py` pins the graph escaping and the absence of external
+  resources in the web UI, complementing the broader 4.0.0 security suite.
+- `test_graph.html`, a generated benchmark artifact, is no longer tracked.
+
+## [4.0.0] - 2026-08-09
+
+Security hardening release (merged via PRs #64 and #65). A parallel
+security/OPSEC pass; the notes below describe what it changed, factually.
+
+### Security
+
+- **Fail-closed network egress choke point.** A single egress layer
+  (`openfoia/net.py`) routes outbound requests and can force everything through
+  Tor's SOCKS5 proxy; if the requested policy cannot be honored the request
+  fails rather than silently going out direct. Crossref and web archiving were
+  routed through it, and the tool's outbound fingerprint was dropped.
+- **`egress-status` command.** Reports honestly whether traffic goes DIRECT or
+  via Tor, whether the Tor proxy is actually reachable, and what is and is not
+  protected.
+- **Graph HTML could execute code from document text.** Untrusted document text
+  and entity labels were spliced into the graph's `<script>` block; a FOIA
+  response containing a literal `</script>` broke out and ran arbitrary
+  JavaScript on `file://`. `escape_json_for_script` now escapes `<`, `>`, `&`,
+  and U+2028/U+2029. Regenerate any `graph.html` produced before this release.
+- **The web UI loaded JavaScript from a CDN.** `openfoia serve` pulled Tailwind
+  from `cdn.tailwindcss.com` on every page load, disclosing your IP and the
+  timing of your sessions. Replaced with a stylesheet served from disk; the web
+  UI now makes zero external requests, sends a restrictive Content-Security-
+  Policy header, rejects non-loopback `Host` headers, and keeps the auth token
+  out of the URL and the `Referer`.
+- **Metadata, resource caps, and at-rest hardening.** Metadata stripping was
+  broadened, downloads and extraction gained size/resource caps, and database
+  file permissions were tightened. The gateways (email, fax, mail) were
+  hardened.
+- **Installer verification fails closed.** `install.sh` verifies the
+  pdf-extract binary against a published `.sha256` and refuses to proceed when
+  it cannot verify, rather than warning and continuing.
+
+## [3.2.2] - 2026-04-10
+
+### Added
+
+- LLM validation now reports keep/remove counts and surfaces errors instead of
+  failing quietly.
+
+### Changed
+
+- The extraction warning distinguishes a local AI provider from a cloud one, so
+  "AI is running" no longer reads the same whether or not documents are leaving
+  the machine.
+
+## [3.2.1] - 2026-04-10
+
+### Added
+
+- Cassette-compatible LLM routing and selectable PDF extraction profiles.
+- Multi-backend extraction pipeline with mention merging and an `--ensemble`
+  mode.
+- LLM used as a validator rather than an extractor, plus junk filtering and
+  OCR-aware fuzzy merging (477 → 333 entities on the benchmark).
+- `--model` flag and Qwen3 support.
+
+### Fixed
+
+- Crossref rate limiting, deduplication, error handling, progress output, and a
+  ProPublica 404.
+- Forced re-extraction (`--force`).
+
+## [3.2.0] - 2026-03-24
+
+### Added
+
+- DocumentCloud adapter and an interactive document reader in the graph view.
+- Multi-layer MuckRock search with cleaner table display.
+- MSG email support and file-type display in search results.
+
+### Fixed
+
+- spaCy auto-download.
+- Web upload text extraction. (The upload path was later routed through the safe
+  ingest API and CSP-hardened in 4.0.0.)
+- Portable-mode config, request-send persistence, and agent draft handling.
+
+## [3.1.1] - 2026-03-23
+
+### Added
+
+- Python CI, a pre-commit hook running ruff lint and format, and `CLAUDE.md`
+  with the project's mission and principles.
+
+### Fixed
+
+- ruff lint and format across the codebase.
+
+## [3.1.0] - 2026-03-23
+
+### Security
+
+- Duress mode redesigned: no stored password hash, an encrypted decoy database,
+  and opaque filenames.
+- Honest security messaging, a written threat model, and install checksums.
+- Addressed seven findings from an adversarial review.
+
+### Fixed
+
+- LLM-extracted entities are validated against the source text.
+- MuckRock search uses tags (the API has no full-text search).
+- The install script searches all releases for the pdf-extract binary.
+
+## [3.0.1] - 2026-03-22
+
+### Changed
+
+- Core install is lightweight; heavy packages are opt-in extras.
+- Every missing-dependency error now names the `openfoia install-extras`
+  command that fixes it.
+
+### Added
+
+- Portable install — the entire app lives on the USB stick.
+
+### Fixed
+
+- Install uses an isolated venv rather than polluting the system Python.
+
+## [3.0.0] - 2026-03-22
+
+Baseline for this changelog. Earlier tags (`v0.0.1` through `v2.0.0`,
+2026-02-19 to 2026-03-22) predate it; see the git history for details.
+
+[4.1.0]: https://github.com/JordanCoin/openfoia/compare/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/JordanCoin/openfoia/compare/v3.2.2...v4.0.0
+[3.2.2]: https://github.com/JordanCoin/openfoia/compare/v3.2.1...v3.2.2
+[3.2.1]: https://github.com/JordanCoin/openfoia/compare/v3.2.0...v3.2.1
+[3.2.0]: https://github.com/JordanCoin/openfoia/compare/v3.1.1...v3.2.0
+[3.1.1]: https://github.com/JordanCoin/openfoia/compare/v3.1.0...v3.1.1
+[3.1.0]: https://github.com/JordanCoin/openfoia/compare/v3.0.1...v3.1.0
+[3.0.1]: https://github.com/JordanCoin/openfoia/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/JordanCoin/openfoia/releases/tag/v3.0.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ Your data never leaves your machine. Works offline. Works everywhere.
 
 ## Install
 
+### With Claude Code (recommended)
+
+If you use [Claude Code](https://claude.ai/code), install the OpenFOIA plugin — you get the CLI plus a built-in copilot that knows every command:
+
+```
+/plugin marketplace add JordanCoin/openfoia
+/plugin install openfoia@openfoia
+/foia-install
+```
+
+The plugin ships a skill that teaches Claude how to run FOIA investigations, plus slash commands for the core loop: `/foia-search`, `/foia-investigate`, `/foia-graph`, `/foia-install`. The last one bootstraps the CLI on your machine.
+
+### Shell install (no Claude Code needed)
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JordanCoin/openfoia/main/install.sh | bash
 ```
@@ -50,7 +64,7 @@ openfoia crossref                                          # check entities agai
 | **Encrypted storage** | SQLCipher AES-256. Decoy profile mode |
 | **Forensic purge** | 3-pass overwrite, shell history scrub, free space fill |
 | **Portable mode** | `openfoia portable` — everything stays on the USB, nothing on the host |
-| **Metadata stripping** | Auto-strips EXIF, PDF author, DOCX revision history on ingest |
+| **Metadata stripping** | Strips EXIF, PDF author, DOCX revision history on file and web-UI ingest. Email attachments and archived web pages are stored as received — see [THREAT_MODEL.md](docs/THREAT_MODEL.md) |
 
 ### PDF Extraction Engine
 

--- a/docs/AIRGAP.md
+++ b/docs/AIRGAP.md
@@ -156,6 +156,25 @@ ollama serve &
 openfoia config --init  # Select "ollama" as the AI provider
 ```
 
+## The Web UI Works Fully Offline
+
+`openfoia serve` needs no internet. It binds to `127.0.0.1`, serves a single
+self-contained HTML page, and fetches nothing from any external host -- the
+stylesheet is hand-written and inlined, there are no web fonts, no CDN
+scripts, and no analytics. The only external URL anywhere on the page is a
+link to the project's GitHub repo in the footer, which does nothing unless
+you click it.
+
+This was not true before v4.0.0: the page loaded Tailwind CSS from
+`cdn.tailwindcss.com`, so every page load made a DNS lookup and a TLS request
+to a third party, and the UI was close to unreadable without one. If you are
+running an older version on an air-gapped machine, expect a broken-looking
+interface -- and on a networked machine, expect the request. Upgrade.
+
+Entity graphs (`openfoia analyze graph --view`) are self-contained too: a
+single HTML file with inline CSS and JS that opens from `file://` with no
+network access at all.
+
 ## Security Checklist
 
 - [ ] Air-gapped machine has no WiFi/Ethernet/Bluetooth enabled
@@ -165,4 +184,6 @@ openfoia config --init  # Select "ollama" as the AI provider
 - [ ] Duress mode configured (`--duress-password`)
 - [ ] Swap disabled or encrypted on the air-gapped machine
 - [ ] Ollama running locally for AI features (no cloud API keys)
+- [ ] Running v4.0.0 or later (earlier versions load CSS from a CDN on every
+      `openfoia serve` page load)
 - [ ] Physical security of the USB drive when not in use

--- a/install.sh
+++ b/install.sh
@@ -81,9 +81,18 @@ download_binary() {
 
     local url
     # Check all releases for binaries (they live on whichever release the
-    # glyph-api CI pushed them to — not necessarily the latest release)
+    # glyph-api CI pushed them to — not necessarily the latest release).
+    #
+    # Match the EXACT asset name: anchor on the leading '/' and the closing
+    # quote. Releases also carry a "<name>.sha256" asset, and an unanchored
+    # substring match hits both — with JSON asset order not guaranteed, the
+    # installer could download the checksum file, chmod +x it, and install
+    # that as the binary. The API lists releases newest-first, so head -1
+    # still picks the most recent release carrying this platform's binary.
+    local name_re
+    name_re=$(printf '%s' "$name" | sed 's/[][\.*^$/]/\\&/g')
     url=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
-        | grep "browser_download_url.*${name}" \
+        | grep -Eo "\"browser_download_url\"[[:space:]]*:[[:space:]]*\"[^\"]*/${name_re}\"" \
         | head -1 \
         | cut -d '"' -f 4) || true
 

--- a/openfoia/__init__.py
+++ b/openfoia/__init__.py
@@ -1,3 +1,3 @@
 """OpenFOIA - Crowdsourced FOIA automation with AI-powered document analysis."""
 
-__version__ = "0.1.0"
+__version__ = "4.1.0"

--- a/openfoia/cli.py
+++ b/openfoia/cli.py
@@ -27,6 +27,28 @@ app = typer.Typer(
 )
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        from . import __version__
+
+        rprint(f"openfoia {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _root(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        help="Show the installed OpenFOIA version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """Crowdsourced FOIA automation with AI-powered document analysis."""
+
+
 # === Init Command ===
 
 
@@ -2571,16 +2593,27 @@ def analyze_graph(
     view: bool = typer.Option(
         False, "--view", "-v", help="Open interactive HTML visualization in browser"
     ),
+    no_text: bool = typer.Option(
+        False,
+        "--no-text",
+        help="Omit full document text from the export (keeps entities, links and context snippets)",
+    ),
 ):
     """Build entity relationship graph from extracted entities.
 
     Use --name to save graphs by investigation name. Each investigation
     gets its own graph that you can revisit later.
 
+    The exported .json and .html files are plaintext and live outside the
+    encrypted database. By default they embed the full text of every document
+    behind the graph, which is what makes the reader view work. Pass --no-text
+    to export the structure without the document bodies.
+
     Examples:
         openfoia analyze graph --view                          # everything, open in browser
         openfoia analyze graph --name defense-contracts --view # save + view
         openfoia analyze graph --request REQ-001 --name epa    # filter + save
+        openfoia analyze graph --no-text --name epa            # structure only, no doc bodies
         openfoia analyze graphs                                # list saved graphs
     """
     from .db import get_db_path, get_session
@@ -2680,7 +2713,7 @@ def analyze_graph(
                     "id": doc.id,
                     "filename": doc.filename or "Unknown",
                     "page_count": doc.page_count,
-                    "text": doc.extracted_text or "",
+                    "text": "" if no_text else (doc.extracted_text or ""),
                     "request_id": doc.request_id,
                     "source_url": source_url,
                 }
@@ -2709,6 +2742,13 @@ def analyze_graph(
         rprint(f"  Relationships: {len(edges)}")
         if name:
             rprint(f"  Saved as: [cyan]{name}[/cyan]")
+        if no_text:
+            rprint("  [dim]Document text omitted (--no-text). The reader view will be empty.[/dim]")
+        elif documents:
+            rprint(
+                "[yellow]Note:[/yellow] this export embeds full document text in plaintext, "
+                "outside the encrypted database — share deliberately, or re-run with --no-text."
+            )
 
         if view:
             _generate_graph_html(graph_data, html_path)

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "openfoia",
+  "description": "Help journalists and researchers run FOIA investigations using the openfoia CLI. Ships a skill covering the full records-search → download → OCR → extract → crossref → graph loop plus slash commands for each phase.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jordan Coin Jackson"
+  },
+  "repository": "https://github.com/JordanCoin/openfoia",
+  "license": "MIT"
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,39 @@
+# OpenFOIA Claude Code plugin
+
+Ships a skill and four slash commands that make Claude a competent copilot for FOIA investigations using the [openfoia CLI](https://github.com/JordanCoin/openfoia).
+
+## What's in the box
+
+- **Skill** — `openfoia`: teaches Claude the full investigation loop (records search → download → OCR → extract → crossref → graph), when to use which extraction tier, privacy warnings before network calls, and how to read FOIA responses critically.
+- **`/foia-install`** — install and initialize the `openfoia` CLI, with a warning before each step that touches the machine.
+- **`/foia-search <topic>`** — multi-source search across MuckRock, OpenCorporates, SEC.
+- **`/foia-investigate <topic or muckrock-id>`** — end-to-end investigation on one request.
+- **`/foia-graph <name or request-id>`** — build or open a saved relationship graph.
+
+## Requires
+
+- `openfoia` CLI installed (`pip install -e ".[dev]"` from the openfoia repo, or `pip install openfoia`)
+- For OCR: `openfoia install-extras ocr` + system `tesseract` and `poppler`
+- For crossref's cloud sources: no API keys needed for public data
+
+## Privacy posture
+
+The skill teaches Claude to warn before any network call. All local operations (ingest, extract without cloud LLM, graph, purge) run entirely on-device. See `docs/THREAT_MODEL.md` in the openfoia repo for what is and isn't protected.
+
+## Install (local dev)
+
+From a clone of this repo:
+
+```bash
+mkdir -p ~/.claude/plugins
+ln -s "$(pwd)/plugin" ~/.claude/plugins/openfoia
+```
+
+Restart Claude Code. Check it loaded with `/help` — you should see the four `/foia-*` commands.
+
+## Install (marketplace)
+
+```
+/plugin marketplace add JordanCoin/openfoia
+/plugin install openfoia@openfoia
+```

--- a/plugin/commands/foia-graph.md
+++ b/plugin/commands/foia-graph.md
@@ -1,0 +1,42 @@
+---
+allowed-tools: Bash(openfoia analyze graph:*), Bash(openfoia analyze graphs:*), Bash(openfoia request list:*), Bash(open:*)
+description: Build or open an investigation graph from extracted entities
+---
+
+Build or open a relationship graph: $ARGUMENTS
+
+The argument can be:
+- **A name of an existing saved graph** (e.g., `clearview-ai`) → open it
+- **A request ID** (e.g., `INGEST-4F14FE` or `DC-25981836`) → build a new graph from that request
+- **Empty or `list`** → list all saved graphs
+
+## Step-by-step
+
+1. **If the argument is empty or "list"**, show all saved graphs:
+   ```bash
+   openfoia analyze graphs
+   ```
+   Then ask the user which one to open, or whether they want to build a new one.
+
+2. **If the argument looks like a saved-graph name** (matches one shown by `openfoia analyze graphs`), open it directly:
+   ```bash
+   open ~/.openfoia/graphs/<name>.html
+   ```
+
+3. **If the argument looks like a request ID** (starts with `DC-`, `REQ-`, `INGEST-`, etc.), build a new graph. Ask the user for a short descriptive name first — graphs without names aren't persisted interactively:
+   ```bash
+   openfoia analyze graph --request <id> --name <slug> --view
+   ```
+
+4. **If ambiguous**, run `openfoia analyze graphs` and `openfoia request list` in parallel to show both, then ask the user to clarify.
+
+## Output to surface
+
+After building:
+- Entity count and relationship count (from the CLI output)
+- File path to the saved HTML
+- Confirm the browser opened
+
+After opening an existing graph, just confirm it's open — don't re-explain what pyvis is.
+
+Keep responses short. The graph is the output; your job is to get the user there.

--- a/plugin/commands/foia-install.md
+++ b/plugin/commands/foia-install.md
@@ -1,0 +1,69 @@
+---
+allowed-tools: Bash(command -v:*), Bash(which:*), Bash(openfoia:*), Bash(curl:*), Bash(pip install:*), Bash(pip3 install:*), Bash(ls:*), Bash(test:*), Bash(cat pyproject.toml)
+description: Install or initialize the openfoia CLI — bootstraps everything the plugin needs to function
+---
+
+Install and initialize the openfoia CLI on this machine.
+
+**This command touches the user's machine** (downloads a binary, runs pip install, creates `~/.openfoia/`). Walk through each step, warn before each one, and stop if the user declines.
+
+## Step 1 — Check what's already there
+
+Run these in parallel to see what state we're in:
+
+```bash
+command -v openfoia
+test -f pyproject.toml && cat pyproject.toml | head -5
+test -d ~/.openfoia && ls ~/.openfoia
+```
+
+Based on the result, pick one of the branches below.
+
+## Branch A — openfoia is already installed
+
+If `command -v openfoia` prints a path:
+
+1. Confirm with the user: "openfoia is already at `<path>`. Version is `<run: openfoia --version>`. Nothing to install."
+   - `--version` was added in 3.3.0. If it errors with "No such option", the install predates it — use `pip show openfoia | head -2` instead and mention that an upgrade is available.
+2. If `~/.openfoia/` doesn't exist, offer to run `openfoia init` (creates the DB + loads 53 federal agencies).
+3. Done. Suggest `/foia-search <topic>` as the next step.
+
+## Branch B — we're in the openfoia repo (source install)
+
+If `pyproject.toml` exists in cwd and contains `name = "openfoia"`:
+
+1. Warn the user: "I'll install openfoia from this local repo with `pip install -e '.[dev]'`. This puts openfoia on your PATH in editable mode. OK?"
+2. On approval, run:
+   ```bash
+   pip install -e ".[dev]"
+   ```
+3. Then initialize the DB:
+   ```bash
+   openfoia init
+   ```
+4. Confirm with `openfoia --version`.
+
+## Branch C — fresh install from the web
+
+If openfoia isn't installed and we're not in the repo:
+
+1. Warn the user: "I'll download and run https://raw.githubusercontent.com/JordanCoin/openfoia/main/install.sh. This will fetch a precompiled `pdf-extract` binary, pip-install openfoia, and create `~/.openfoia/`. OK to proceed?"
+2. On approval, run:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/JordanCoin/openfoia/main/install.sh | bash
+   ```
+3. Confirm with `openfoia --version`.
+
+## After any branch succeeds
+
+Tell the user what they can do next — succinctly:
+
+- `/foia-search <topic>` — search MuckRock for existing FOIAs
+- `/foia-investigate <topic>` — full investigation loop
+- `openfoia guide` — interactive quickstart
+
+If the install failed, surface the exact error and suggest either:
+- `openfoia install-extras ocr` (if a later step needs OCR)
+- Checking the openfoia repo README at https://github.com/JordanCoin/openfoia
+
+Keep the response short. The user mostly cares whether it worked, not the step-by-step.

--- a/plugin/commands/foia-investigate.md
+++ b/plugin/commands/foia-investigate.md
@@ -1,0 +1,64 @@
+---
+allowed-tools: Bash(openfoia:*)
+description: Run the full FOIA investigation loop on a topic or MuckRock ID — search, download, OCR, extract, crossref, and graph
+---
+
+Run an end-to-end FOIA investigation on: $ARGUMENTS
+
+The argument can be either a topic (like `Palantir contracts`) or a MuckRock request ID (like `195614`). If it's numeric, treat it as a MuckRock ID and skip the search step.
+
+**Before running:** tell the user in plain language what network calls this will make — MuckRock for search/download, plus 10+ sources for crossref. Get explicit go-ahead.
+
+## Step-by-step
+
+1. **Search (if the argument is a topic, not an ID)**
+   ```bash
+   openfoia records search "$ARGUMENTS" --source muckrock --limit 10
+   ```
+   Show results, then ask the user which ID to investigate. Stop here until they pick one.
+
+2. **Download the PDFs**
+   ```bash
+   openfoia records download <id> --source muckrock
+   ```
+   List what came down. Flag any obvious boilerplate ("Responsive Records Attached", "Fee Waiver", etc.) vs. the likely substantive records.
+
+3. **Ingest** — ask the user which file to focus on, or offer to ingest all with `--recursive`:
+   ```bash
+   openfoia docs ingest downloads/<file>.pdf
+   ```
+   Note the document ID returned.
+
+4. **Try extract first**
+   ```bash
+   openfoia analyze extract <doc-id>
+   ```
+   If entity count is very low (< 3 non-date entities) and the file is likely scanned, proceed to step 5. Otherwise skip to step 6.
+
+5. **OCR if needed**
+   ```bash
+   openfoia docs ocr downloads/<file>.pdf -o /tmp/<file>.txt
+   openfoia analyze extract <doc-id> --force
+   ```
+
+6. **Read the extraction output critically.** Name any entity that looks like a false positive (keyword collision, OCR artifact). Explain what the document actually says vs. what the request asked for — the gap itself is often the story.
+
+7. **Crossref, scoped to this request**
+   Find the request ID with `openfoia request list`, then:
+   ```bash
+   openfoia crossref -r <request-id>
+   ```
+   Read the hits. Call out any flagged entities that appear in multiple sources — those are the investigative leads.
+
+8. **Build the graph**
+   ```bash
+   openfoia analyze graph --request <request-id> --name <slug> --view
+   ```
+   Pick a short, descriptive slug (e.g., `palantir-el-cajon`, `clearview-chicago`). `--view` opens the interactive HTML in the browser.
+
+9. **Summarize the finding.** Three things:
+   - What the user asked the agency for
+   - What the agency actually disclosed
+   - Whether the response was substantively responsive or a null-response-as-compliance pattern (agencies often search their vendor DB on a keyword and ship whatever matches, regardless of whether it relates)
+
+Keep the narrative tight and honest. If the investigation hit a dead end (wrong entity, no matches, scanned doc that OCR couldn't read), say so and suggest the next thread to pull.

--- a/plugin/commands/foia-search.md
+++ b/plugin/commands/foia-search.md
@@ -1,0 +1,31 @@
+---
+allowed-tools: Bash(openfoia records search:*), Bash(openfoia agency search:*)
+description: Search MuckRock, OpenCorporates, and SEC for existing records on a topic before filing a new FOIA
+---
+
+Search public records for the user's topic: $ARGUMENTS
+
+**Before running:** confirm with the user in one sentence that this hits external APIs (MuckRock, OpenCorporates, SEC). Only skip the warning if the user has already approved network use in this session.
+
+Follow these steps:
+
+1. Run MuckRock first — that's where completed FOIA responses live:
+   ```bash
+   openfoia records search "$ARGUMENTS" --source muckrock --limit 15
+   ```
+
+2. If the topic is a company/organization, also check OpenCorporates and SEC in parallel:
+   ```bash
+   openfoia records search "$ARGUMENTS" --source opencorporates --limit 10
+   openfoia records search "$ARGUMENTS" --source sec --limit 10
+   ```
+
+3. Read the MuckRock results and group by angle (e.g., "police departments", "public health", "universities") so the user can pick a thread.
+
+4. If MuckRock returns 0 results, surface that clearly and suggest:
+   - Trying a broader or differently-phrased query
+   - Filing a new request via `/foia-investigate` or `openfoia request new`
+
+5. End by suggesting the next step — either `/foia-investigate <muckrock-id>` to run the full loop on a specific result, or `openfoia records download <id>` to just pull the PDFs.
+
+Keep your output tight. Raw CLI tables are fine; don't re-format them into prose.

--- a/plugin/skills/openfoia/SKILL.md
+++ b/plugin/skills/openfoia/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: openfoia
+description: Use this skill when helping a journalist, researcher, or citizen run FOIA investigations using the openfoia CLI — searching public records (MuckRock, SEC EDGAR, OpenCorporates, DocumentCloud), downloading FOIA response PDFs, running OCR, extracting entities (people, orgs, dates, money), cross-referencing entities against investigative databases, building relationship graphs, or filing new FOIA requests. Trigger whenever the user mentions FOIA, public records, freedom of information, government transparency, document analysis for investigations, entity extraction from PDFs, Palantir/Clearview-style investigations, or specific openfoia commands. Also trigger when the user is in a directory where `openfoia` is installed and they ask about analyzing documents, even if they don't say "FOIA" explicitly.
+---
+
+# OpenFOIA investigation copilot
+
+You are assisting someone using OpenFOIA — a local-first, privacy-preserving FOIA automation tool — to investigate public records. The tool runs entirely on the user's machine unless they explicitly opt into network calls. Safety comes before speed.
+
+**If the `openfoia` command is not installed** (check with `command -v openfoia`), tell the user to run `/foia-install` before anything else. Don't try to install it yourself — `/foia-install` walks through the options with proper warnings.
+
+## Core mental model
+
+OpenFOIA is organized around one investigation loop:
+
+```
+records search   →   download   →   OCR   →   extract   →   crossref   →   graph
+(external APIs)      (PDFs)       (if scanned)  (entities)   (confirm)    (visualize)
+```
+
+Every step writes to a single SQLite database at `~/.openfoia/openfoia.db`. Document bytes live on disk at `~/.openfoia/docs/<uuid>.pdf`. Graphs are saved HTML + JSON under `~/.openfoia/graphs/<name>.html`.
+
+## Before running anything that touches the network
+
+Commands that leave the machine: `records search/fetch/download`, `crossref`, `request send`, `ingest --url <url>` (top-level web page ingest), `browse` (Tor routes to the target URL), and `analyze extract` when the configured AI provider is a cloud one (the provider comes from config, not from `--model`). Every other command is offline.
+
+Before running these, warn the user in one sentence — what's about to be sent where. Don't be preachy, just honest. Example:
+
+> "This hits MuckRock's API — your search query and the entity names go to their servers. OK to proceed?"
+
+If the user has already approved network use in this session, don't re-warn for the same source.
+
+## The investigation loop, step by step
+
+### 1. Records search — find existing FOIA responses before filing a new one
+
+```bash
+openfoia records search "Palantir" --source muckrock --limit 15
+openfoia records search "Acme Corp" --source opencorporates -j us_ca
+openfoia records search "Anthropic" --source sec --type 10-K
+```
+
+MuckRock is the primary source for completed FOIA responses (~150k requests). OpenCorporates is for company registration lookups. SEC is for US public company filings. The API has no full-text search on MuckRock — it falls back through tags → agency → user filters internally.
+
+**When to suggest filing a new request instead:** if search returns 0 results across sources, or if results are all old/irrelevant, pivot to `openfoia request new`.
+
+### 2. Download or fetch — grab the PDFs
+
+```bash
+openfoia records download <muckrock-id> --source muckrock    # download all files for a request
+openfoia records fetch <id> --source documentcloud           # fetch full text of a single document into DB
+openfoia ingest --url <url>                                  # ingest a web page as a document (network!)
+```
+
+`download` pulls all response documents to `./downloads/` — does NOT auto-ingest. `fetch` pulls a single document's text directly into the DB (useful when you just want text, not the PDF bytes); **`fetch` only supports `--source documentcloud`** — for MuckRock use `records download`. `openfoia ingest --url <url>` (top-level, distinct from `docs ingest`) scrapes a web page and stores it as a document — warn before running, it hits whatever URL you pass.
+
+Review filenames before ingest — FOIA responses often contain cover letter + actual records + boilerplate denials mixed in.
+
+### 3. Ingest — bring a document into OpenFOIA's storage
+
+```bash
+openfoia docs ingest downloads/<file>.pdf
+openfoia docs ingest downloads/ --recursive
+openfoia docs ingest ./doc.pdf -r REQ-2026-001   # associate with a request
+```
+
+Ingest automatically strips metadata (EXIF, author, producer, creation date). The `--keep-metadata` flag is available but should be used cautiously — stripping is the safe default, and some metadata can deanonymize the source.
+
+After ingest, each document gets a UUID. The short form (first 8 chars) works for most commands.
+
+### 4. OCR — only if the PDF is scanned
+
+```bash
+openfoia docs ocr downloads/<file>.pdf -o /tmp/out.txt
+```
+
+If `analyze extract` returns very few entities and the PDF is scanned (images of text, not text), OCR first. Requires `openfoia install-extras ocr` plus system-level `tesseract` and `poppler`.
+
+### 5. Extract — pull entities from document text
+
+```bash
+openfoia analyze extract <doc-id>                      # default: LLM-validated
+openfoia analyze extract <doc-id> --ensemble           # run all NER backends
+openfoia analyze extract <doc-id> --model <model-name>   # provider comes from config, not this flag
+openfoia analyze extract <doc-id> --force              # re-extract
+```
+
+Four-tier fallback pipeline: LLM → GLiNER → spaCy → regex. Regex always works. Each tier is better than the one below it, but all have cost tradeoffs. The LLM validation step keeps/removes entities based on document context (e.g., will keep "SOUTH BAY FOUNDRY, INC" as a real organization but flag an OCR artifact as junk).
+
+**Entity types extracted:** person, organization, location, date, money, document_id, phone, email, address.
+
+### 6. Crossref — check entities against investigative databases
+
+```bash
+openfoia crossref -r <request-id>     # scope to one request
+openfoia crossref -d <doc-id>         # scope to one document
+openfoia crossref                     # everything (can be slow)
+openfoia crossref --sources icij      # offline only, needs ICIJ CSVs downloaded
+```
+
+Sources include MuckRock, OpenCorporates, SEC EDGAR, DocumentCloud, OpenSanctions, ICIJ Offshore Leaks, USAspending, FEC, govinfo, regulations.gov. This is the equivalent of Maltego's paid service but free and local-first.
+
+**Always scope crossref** to a request or document unless the user explicitly wants to re-check everything. Full-DB crossref hammers 10+ APIs for every entity in the database.
+
+Crossref output flags entities that appear in multiple sources — that's the interesting signal (e.g., a vendor named in a FOIA response AND listed as a government contractor AND appearing on a sanctions list).
+
+### 7. Graph — visualize the relationships
+
+```bash
+openfoia analyze graph --view                                      # everything
+openfoia analyze graph --request <id> --name my-investigation --view
+openfoia analyze graph --campaign <id> --name campaign-graph --view
+openfoia analyze graph --request <id> --name my-investigation --no-text   # omit document bodies
+openfoia analyze graphs                                            # list saved
+```
+
+Graphs render as a single self-contained HTML file (inline CSS/JS, no external dependencies, no network access) saved to `~/.openfoia/graphs/<name>.html`. Use `--name` to save — unnamed graphs export to `graph.json` in the cwd, and `--view` writes the HTML alongside it.
+
+**Tell the user what a graph file contains.** By default the export embeds the full extracted text of every document, in plaintext, outside the encrypted database — so the HTML/JSON is the whole investigation in one shareable file. Pass `--no-text` to export just the entities and relationships. The command prints a one-line reminder when text is included; don't let the user email a graph without knowing what's in it.
+
+## How to read the output of a run
+
+- **"LLM validation: keep=N, remove=M"** — the LLM validator kept N entities as real and removed M as junk. Big removal numbers usually mean OCR noise or a regex false positive.
+- **"from N entities"** — the raw extraction count before validation.
+- **Confidence < 70%** — eyeball it. Often real, sometimes junk.
+- **"No entities found"** on a non-scanned PDF — likely a parser failure, not a document problem. Try `--ensemble`.
+
+## Filing a new request
+
+```bash
+openfoia agency search "Police Department" -n 30   # -n is the result limit; there is no state filter
+openfoia request new -a <agency-id> -s "subject" -f request-body.txt -n "Full Name" -e "you@email"
+openfoia request send -a <agency-id> -s "subject" -b "body text" -n "Full Name" -e "you@email"
+
+```
+
+Use `openfoia template list` for pre-written FOIA boilerplate. Always double-check the delivery method (`email`, `fax`, `mail`) matches the agency's preference — `agency info <id>` shows `preferred_method`.
+
+## Campaigns — crowdsource the same request
+
+```bash
+openfoia campaign create -n "Palantir Contracts 2026" -d "Contracts and comms" -t body.txt --organizer "Jane Doe" -e jane@example.com --target 500
+openfoia campaign distribute <id>    # assigns requests to participants
+openfoia campaign progress <id>      # per-participant status grid
+```
+
+Campaigns let one investigation run against hundreds of agencies. Matches MuckRock's Assignments model but runs locally.
+
+## Honest limits worth calling out
+
+- **No versioned extraction runs.** `--force` re-extract overwrites entities. There's no audit trail of "what did Claude-Haiku say last week vs. Claude-Opus today." Tracked in issue #63.
+- **DB is NOT encrypted by default.** Users must run `openfoia install-extras encryption` to enable SQLCipher.
+- **"Purge" means purge.** `openfoia purge` deletes everything and is not reversible. Confirm twice. It is a normal delete unless `--secure` is passed, and even then SSD wear-levelling means old blocks may survive — say so rather than promising erasure.
+- **Optional deps are lazy-imported.** If the user hits `ModuleNotFoundError`, point them to `openfoia install-extras <name>` rather than digging into pip.
+
+## Tone and posture
+
+The people using this tool are investigating power — often under real pressure, sometimes in hostile environments. Be direct, honest about limits, and skeptical of false positives. When in doubt about a warning, issue it. When a FOIA response looks like a "null response dressed as compliance" (e.g., the agency searched for "Foundry" as a vendor name and returned a metal shop), call it out explicitly — that pattern matters for the investigation.
+
+## Other subsystems worth knowing
+
+These aren't part of the core loop but come up often enough to keep in mind.
+
+### Custom entity types — extend what the extractor looks for
+```bash
+openfoia entities list                        # show built-in + custom types
+openfoia entities add --name vessel --pattern "IMO \d{7}"   # regex-based
+openfoia entities import my-types.csv         # bulk import (CSV or Excel, NOT JSON)
+openfoia entities test -t "<sample text>"     # dry-run all types against sample text (also -f <file> or stdin)
+```
+Custom types slot into the regex fallback tier — useful for domain-specific patterns (ship IMOs, case numbers, contract IDs) that general NER misses.
+
+### Deadlines — statutory FOIA response tracking
+```bash
+openfoia deadlines list            # all open requests with due dates
+openfoia deadlines check           # flag overdue requests
+```
+Due dates are computed from `Agency.typical_response_days` at send time. Federal FOIA default is 20 business days.
+
+### Templates — FOIA boilerplate
+```bash
+openfoia template list             # available templates
+openfoia template generate standard -a FBI -s "Records on X" -n "Your Name" -e you@example.com -o draft.txt
+openfoia template exemptions       # reference for b(1)-b(9) exemption codes
+```
+Templates include contract requests, communications, personnel records, etc. Use `exemptions` when reading denials — agencies often cite b(5) (deliberative process) or b(7)(A) (law enforcement) to withhold.
+
+### FollowTheMoney (FTM) export/import — integrate with Aleph/OCCRP
+```bash
+openfoia analyze export -o investigation.ftm.json
+openfoia analyze import aleph-export.ftm.json
+```
+FTM is the open standard for investigative data exchange. Export puts OpenFOIA's entities + relationships into the format Aleph, OCCRP's stack, and most investigative tooling reads natively.
+
+### Web UI — local server with token auth
+```bash
+openfoia serve                     # binds a random free port; prints the URL + token
+```
+Bound to localhost only. The default port is `0`, meaning a random free port — there is no fixed 8000. On start it prints the full URL including a `?token=...`; that token is required. The page loads nothing from the network.
+
+### Privacy tools
+
+```bash
+openfoia egress-status             # show whether traffic goes DIRECT or via Tor, honestly
+openfoia egress-status --tor       # check the Tor mode instead of the configured default
+openfoia portable                  # move all data beside the binary (USB-safe)
+openfoia browse <url>              # visit a URL with Tor routing + fingerprint hardening
+openfoia purge                     # delete everything (irreversible)
+openfoia purge --secure            # 3-pass overwrite before deleting (opt-in)
+```
+`egress-status` reports the current network egress policy — DIRECT vs TOR, whether the Tor SOCKS proxy is actually reachable right now, and exactly what is and isn't protected (see `docs/THREAT_MODEL.md`). Run it before any command that hits the network. `portable` is for journalists moving between machines — the DB and docs travel with the binary, no traces in `~/.openfoia`. `browse` uses the Tor SOCKS proxy (user must have tor running). Plain `purge` is an ordinary delete; multi-pass overwriting is opt-in via `--secure` (and `--fill` for free space). Note that on SSDs overwriting does not reliably erase the old blocks — full-disk encryption is the real protection. Don't promise more than that.
+
+### Config, setup, migration
+```bash
+openfoia init                      # first-time DB setup
+openfoia guide                     # interactive quickstart
+openfoia config --init             # interactive first-time config
+openfoia config --show             # print current config (also via OPENFOIA_* env or ~/.openfoia/config.json)
+openfoia install-extras <name>     # ner, ocr, fax, mail, cloud-ai, tor, browser, encryption, all
+openfoia db upgrade                # run Alembic migrations
+openfoia db encrypt --password <pw>  # convert plaintext DB to SQLCipher (AES-256)
+```
+
+### Request and agency lookup (alongside the core loop)
+```bash
+openfoia request list              # all requests, status, days pending
+openfoia request status <id>       # detailed timeline of one request
+openfoia agency list               # all agencies in the DB
+openfoia agency info <id>          # contact info + preferred delivery method + stats
+openfoia campaign list             # all campaigns
+openfoia campaign status <id>      # progress summary
+openfoia campaign join <id> -n "Your Name" -e you@example.com   # opt into someone else's campaign
+```
+
+## Quick reference
+
+| I want to... | Command |
+|-----|-----|
+| Find existing FOIAs on a topic | `openfoia records search "<topic>" --source muckrock` |
+| Download response PDFs | `openfoia records download <id> --source muckrock` |
+| Add PDFs to the database | `openfoia docs ingest <path>` |
+| OCR a scanned PDF | `openfoia docs ocr <path> -o <out>` |
+| Pull entities from a doc | `openfoia analyze extract <doc-id>` |
+| Verify entities exist elsewhere | `openfoia crossref -r <req-id>` |
+| Build/view a graph | `openfoia analyze graph --name <n> --view` |
+| List saved graphs | `openfoia analyze graphs` |
+| Export to FollowTheMoney | `openfoia analyze export -o <file>.ftm.json` |
+| File a new request | `openfoia request new -a <agency> -s "..." -f body.txt -n "Name" -e you@example.com` |
+| See all my requests | `openfoia request list` |
+| Start a campaign | `openfoia campaign create -n "..." -d "..." -t body.txt --organizer "..." -e you@example.com` |
+| Check FOIA deadlines | `openfoia deadlines list` |
+| Find an agency | `openfoia agency search "<name>"` |
+| Add custom entity type | `openfoia entities add --name <type> --pattern "<regex>"` |
+| Start the web UI | `openfoia serve` (localhost only, token auth) |
+| Enable USB portable mode | `openfoia portable` |
+| Encrypt the database | `openfoia install-extras encryption && openfoia db encrypt --password <pw>` |
+| Purge everything | `openfoia purge` (irreversible; `--secure` for overwrite) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openfoia"
-version = "4.0.0"
+version = "4.1.0"
 description = "Local-first investigation toolkit for journalists, researchers, and citizens"
 readme = "README.md"
 license = "AGPL-3.0"
@@ -62,6 +62,9 @@ dev = [
     "pytest-cov>=4.1.0",
     "ruff>=0.1.0",
     "mypy>=1.8.0",
+    # tests/test_plugin.py parses plugin frontmatter. Test-only -- keep it out
+    # of core deps.
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/tests/benchmark_extraction.py
+++ b/tests/benchmark_extraction.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 
 from openfoia.config import load_config
+from openfoia.graph_template import escape_json_for_script
 from openfoia.pipeline.extract import (
     EntityExtractor,
     _gliner_available,
@@ -198,8 +199,11 @@ def generate_graph_html(result, output_path):
 
     graph_data = json.dumps({"nodes": nodes, "edges": edges})
 
-    # Write the HTML file with embedded graph data
-    output_path.write_text(_GRAPH_HTML_TEMPLATE.replace("__GRAPH_DATA__", graph_data))
+    # Write the HTML file with embedded graph data. The JSON is spliced straight
+    # into a <script> element, so it must be escaped — see escape_json_for_script.
+    output_path.write_text(
+        _GRAPH_HTML_TEMPLATE.replace("__GRAPH_DATA__", escape_json_for_script(graph_data))
+    )
     print(f"\nGraph saved to {output_path}")
 
 
@@ -226,7 +230,7 @@ canvas{display:block}
 </div>
 <div id="sel"></div>
 <script>
-const D=JSON.parse('__GRAPH_DATA__');
+const D=__GRAPH_DATA__;
 const N=D.nodes,E=D.edges;
 const cv=document.getElementById('c'),cx=cv.getContext('2d');
 let W,H;

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,323 @@
+"""Tests for the Claude Code plugin shipped in plugin/.
+
+Catches drift between the openfoia CLI surface and what SKILL.md documents:
+if a new command group is added but not mentioned in the skill, the test fails.
+"""
+
+import json
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+import typer.main
+import yaml
+
+from openfoia.cli import app
+
+REPO_ROOT = Path(__file__).parent.parent
+PLUGIN_DIR = REPO_ROOT / "plugin"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_JSON = PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+SKILL_MD = PLUGIN_DIR / "skills" / "openfoia" / "SKILL.md"
+COMMANDS_DIR = PLUGIN_DIR / "commands"
+
+
+def _parse_frontmatter(markdown: str) -> dict:
+    """Extract YAML frontmatter from a markdown file, or return {}."""
+    if not markdown.startswith("---\n"):
+        return {}
+    end = markdown.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    return yaml.safe_load(markdown[4:end]) or {}
+
+
+def _cli_command_names() -> set[str]:
+    """Every top-level openfoia command — both @app.command and add_typer groups."""
+    names = set()
+    for cmd in app.registered_commands:
+        if cmd.name:
+            names.add(cmd.name)
+        elif cmd.callback:
+            names.add(cmd.callback.__name__.replace("_", "-"))
+    for group in app.registered_groups:
+        if group.name:
+            names.add(group.name)
+    return names
+
+
+def _click_root():
+    """The CLI as a click Group -- the real command tree, not a guess at it."""
+    return typer.main.get_command(app)
+
+
+def _iter_code_snippets(markdown: str):
+    """Yield every fenced code block and inline code span in a markdown file.
+
+    Only code is checked. Prose mentioning "the openfoia CLI" is not an
+    invocation and must not be parsed as one.
+    """
+    fenced = re.findall(r"```[a-z]*\n(.*?)```", markdown, re.S)
+    for block in fenced:
+        yield from block.splitlines()
+    stripped = re.sub(r"```[a-z]*\n.*?```", "", markdown, flags=re.S)
+    yield from re.findall(r"`([^`\n]+)`", stripped)
+
+
+def _iter_invocations(markdown: str):
+    """Yield token lists for every `openfoia ...` command found in code."""
+    for snippet in _iter_code_snippets(markdown):
+        snippet = snippet.strip()
+        # Drop trailing comments and shell pipelines/chains.
+        snippet = snippet.split("#", 1)[0].strip()
+        for part in re.split(r"&&|\|\||\||;", snippet):
+            part = part.strip()
+            if not part.startswith("openfoia"):
+                continue
+            try:
+                tokens = shlex.split(part)
+            except ValueError:
+                continue
+            if len(tokens) > 1:
+                yield part, tokens[1:]
+
+
+def _plugin_markdown_files():
+    return [SKILL_MD, *sorted(COMMANDS_DIR.glob("*.md"))]
+
+
+class Parsed:
+    """One `openfoia ...` invocation resolved against the real command tree."""
+
+    def __init__(self, error=None, cmd=None, path=(), positionals=0, flags=()):
+        self.error = error
+        self.cmd = cmd
+        self.path = tuple(path)
+        self.positionals = positionals
+        self.flags = tuple(flags)
+
+    @property
+    def label(self):
+        return "openfoia " + " ".join(self.path)
+
+
+def _parse_invocation(root, tokens):
+    """Resolve tokens against the CLI, separating flags from positionals.
+
+    Option values must not be counted as positional arguments -- in
+    `records search "x" --source muckrock`, "muckrock" belongs to --source.
+    """
+    words = [t for t in tokens if not t.startswith("-")]
+    if not words:
+        return Parsed()  # e.g. `openfoia --version`
+
+    cmd = root.get_command(None, words[0])
+    if cmd is None:
+        return Parsed(error=f"no such command 'openfoia {words[0]}'")
+
+    path = [words[0]]
+    if hasattr(cmd, "get_command"):
+        if len(words) < 2:
+            return Parsed(cmd=cmd, path=path)  # a group named on its own
+        sub = cmd.get_command(None, words[1])
+        if sub is None:
+            return Parsed(error=f"no such subcommand 'openfoia {words[0]} {words[1]}'")
+        cmd, path = sub, [words[0], words[1]]
+
+    # Which flags consume the following token?
+    takes_value = {}
+    for param in cmd.params:
+        wants = not getattr(param, "is_flag", False) and getattr(param, "nargs", 1) != 0
+        for opt in list(param.opts) + list(param.secondary_opts):
+            takes_value[opt] = wants
+
+    rest = tokens[len(path) :]
+    positionals, flags, skip = 0, [], False
+    for token in rest:
+        if skip:
+            skip = False
+            continue
+        if token.startswith("-") and token != "-":
+            flag = token.split("=", 1)[0]
+            flags.append(flag)
+            if "=" not in token and takes_value.get(flag, False):
+                skip = True
+        else:
+            positionals += 1
+    return Parsed(cmd=cmd, path=path, positionals=positionals, flags=flags)
+
+
+def _iter_parsed():
+    """Yield (path, raw_command, Parsed) for every invocation in the plugin."""
+    root = _click_root()
+    for path in _plugin_markdown_files():
+        for raw, tokens in _iter_invocations(path.read_text()):
+            yield path, raw, _parse_invocation(root, tokens)
+
+
+class TestMarketplaceAndPluginManifests:
+    def test_marketplace_json_is_valid(self):
+        data = json.loads(MARKETPLACE_JSON.read_text())
+        assert data["name"] == "openfoia"
+        assert len(data["plugins"]) >= 1
+
+    def test_plugin_json_is_valid(self):
+        data = json.loads(PLUGIN_JSON.read_text())
+        assert data["name"] == "openfoia"
+        assert "version" in data
+        assert "description" in data
+
+    def test_marketplace_and_plugin_names_match(self):
+        marketplace = json.loads(MARKETPLACE_JSON.read_text())
+        plugin = json.loads(PLUGIN_JSON.read_text())
+        marketplace_plugin = next(p for p in marketplace["plugins"] if p["name"] == plugin["name"])
+        assert marketplace_plugin is not None
+
+    def test_marketplace_source_resolves_to_plugin_dir(self):
+        marketplace = json.loads(MARKETPLACE_JSON.read_text())
+        source = marketplace["plugins"][0]["source"]
+        resolved = (MARKETPLACE_JSON.parent.parent / source).resolve()
+        assert resolved == PLUGIN_DIR.resolve()
+        assert (resolved / ".claude-plugin" / "plugin.json").exists()
+
+
+class TestSkillFrontmatter:
+    def test_skill_md_exists(self):
+        assert SKILL_MD.exists()
+
+    def test_skill_md_has_required_frontmatter(self):
+        frontmatter = _parse_frontmatter(SKILL_MD.read_text())
+        assert frontmatter.get("name") == "openfoia"
+        assert isinstance(frontmatter.get("description"), str)
+        assert len(frontmatter["description"]) > 100, (
+            "Description should be substantive — it's the primary trigger signal"
+        )
+
+
+class TestCommandFrontmatter:
+    @pytest.fixture
+    def command_files(self):
+        return sorted(COMMANDS_DIR.glob("*.md"))
+
+    def test_commands_exist(self, command_files):
+        names = {f.stem for f in command_files}
+        assert names == {"foia-search", "foia-investigate", "foia-graph", "foia-install"}
+
+    def test_every_command_has_description_and_tools(self, command_files):
+        for cmd_file in command_files:
+            frontmatter = _parse_frontmatter(cmd_file.read_text())
+            assert "description" in frontmatter, f"{cmd_file.name} missing description frontmatter"
+            assert "allowed-tools" in frontmatter, (
+                f"{cmd_file.name} missing allowed-tools — should scope blast radius"
+            )
+
+    def test_allowed_tools_scoped_to_openfoia(self, command_files):
+        """Commands should not wildcard all tools — they should scope to openfoia."""
+        for cmd_file in command_files:
+            frontmatter = _parse_frontmatter(cmd_file.read_text())
+            tools = frontmatter.get("allowed-tools", "")
+            assert "openfoia" in tools or "open:" in tools, (
+                f"{cmd_file.name} allowed-tools should reference openfoia: {tools!r}"
+            )
+
+
+class TestSkillCoversEntireCliSurface:
+    """The load-bearing test: catches drift when new CLI commands are added
+    without corresponding updates to SKILL.md."""
+
+    def test_every_documented_invocation_resolves_to_a_real_command(self):
+        """Every `openfoia <group> <subcommand>` in the plugin must exist.
+
+        The group-name grep below cannot catch this: `openfoia config get`
+        and `openfoia entities test <name> <text>` both contain a valid group
+        name while being commands that do not exist. A skill that teaches
+        Claude wrong invocations burns the user's turns on errors.
+        """
+        failures = []
+        for path, raw, parsed in _iter_parsed():
+            if parsed.error:
+                failures.append(f"{path.name}: {parsed.error}  --  {raw}")
+                continue
+            if parsed.cmd is None or hasattr(parsed.cmd, "get_command"):
+                continue
+
+            # Extra positionals are the other way docs go wrong: `config get`
+            # and `entities test <name> <text>` both resolve to a real command
+            # and then die on unexpected arguments.
+            args = [q for q in parsed.cmd.params if getattr(q, "param_type_name", "") == "argument"]
+            if any(getattr(q, "nargs", 1) == -1 for q in args):
+                continue
+            allowed = sum(max(getattr(q, "nargs", 1), 0) for q in args)
+            if parsed.positionals > allowed:
+                failures.append(
+                    f"{path.name}: '{parsed.label}' takes {allowed} positional argument(s), "
+                    f"example passes {parsed.positionals}  --  {raw}"
+                )
+
+        assert not failures, "Plugin docs reference commands that do not exist:\n" + "\n".join(
+            failures
+        )
+
+    def test_every_documented_flag_exists_on_its_command(self):
+        """Flags in the plugin docs must exist on the command they are used with.
+
+        Catches the other half of the drift: `agency search -s ca` and
+        `campaign create -f body.txt` both name real commands with flags the
+        command does not accept.
+        """
+        failures = []
+        for path, raw, parsed in _iter_parsed():
+            if parsed.error or parsed.cmd is None:
+                continue
+            valid = {o for q in parsed.cmd.params for o in q.opts}
+            valid |= {o for q in parsed.cmd.params for o in q.secondary_opts}
+            valid.add("--help")
+            for flag in parsed.flags:
+                if flag not in valid:
+                    failures.append(
+                        f"{path.name}: '{parsed.label}' has no option {flag}  --  {raw}"
+                    )
+
+        assert not failures, "Plugin docs use flags that do not exist:\n" + "\n".join(failures)
+
+    def test_every_documented_required_option_is_shown(self):
+        """If a command has required options, the docs must not omit them.
+
+        `template generate <name> -o draft.txt` looks fine and errors out --
+        it omits four required options.
+
+        Only invocations that already pass at least one flag are checked: a
+        bare `openfoia request new` in prose is a reference to the command,
+        not an example someone is meant to paste.
+        """
+        failures = []
+        for path, raw, parsed in _iter_parsed():
+            if parsed.error or parsed.cmd is None or not parsed.flags:
+                continue
+            used = set(parsed.flags)
+            for param in parsed.cmd.params:
+                if not getattr(param, "required", False):
+                    continue
+                if getattr(param, "param_type_name", "") == "argument":
+                    continue  # positional; presence is covered by the arity check
+                if not used & set(param.opts):
+                    failures.append(
+                        f"{path.name}: '{parsed.label}' requires {'/'.join(param.opts)} "
+                        f"but the example omits it  --  {raw}"
+                    )
+
+        assert not failures, "Plugin docs show commands missing required options:\n" + "\n".join(
+            failures
+        )
+
+    def test_skill_md_mentions_every_top_level_command(self):
+        skill_text = SKILL_MD.read_text()
+        cli_commands = _cli_command_names()
+
+        missing = sorted(cmd for cmd in cli_commands if cmd not in skill_text)
+        assert not missing, (
+            f"SKILL.md is missing documentation for {len(missing)} CLI commands: "
+            f"{missing}. When you add a command to openfoia/cli.py, also add it "
+            f"to plugin/skills/openfoia/SKILL.md so Claude stays in sync."
+        )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,126 @@
+"""Regression tests pinning graph-injection and offline-web-UI guarantees.
+
+These are cheap, offline, and deliberately narrow: each one locks a specific
+defect that must not come back. They complement the broader v4.0.0 security
+suite (tests/test_security_injection.py, tests/test_security_network.py).
+
+- C7: document text was spliced raw into the graph's <script> block, so a PDF
+  containing `</script>` broke out and executed on `file://`. v4.0.0's
+  escape_json_for_script escapes `<`, `>`, `&` and U+2028/U+2029.
+- C6: the web UI must load nothing from a CDN, so merely opening it never
+  phones a third party.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from openfoia.graph_template import escape_json_for_script, render
+from openfoia.server import get_index_html
+
+# A document body that breaks out of a <script> block and runs attacker JS.
+PAYLOAD = "</script><script>window.PWNED=1</script>"
+
+
+def _render_graph(tmp_path, doc_text):
+    graph_data = {
+        "nodes": [{"id": "e1", "label": "Acme Corp", "type": "organization"}],
+        "edges": [],
+        "documents": {
+            "d1": {
+                "id": "d1",
+                "filename": "response.pdf",
+                "page_count": 1,
+                "text": doc_text,
+                "request_id": "REQ-001",
+                "source_url": None,
+            }
+        },
+    }
+    out = tmp_path / "graph.html"
+    render(json.dumps(graph_data), out)
+    return out.read_text()
+
+
+class TestGraphScriptInjection:
+    """C7 -- graph HTML must not let document text break out of <script>."""
+
+    def test_payload_does_not_close_the_script_block(self, tmp_path):
+        html = _render_graph(tmp_path, PAYLOAD)
+
+        # The data block starts at `var graphData =` and the only `</script>`
+        # after it must be the template's own closing tag.
+        start = html.index("var graphData =")
+        data_block = html[start : html.index("</script>", start)]
+
+        assert "</script>" not in data_block
+        # If the payload text appears, its opening `<` must be \u003c-escaped so
+        # it cannot start or close a tag. v4.0.0 escapes both `<` and `>`.
+        assert "window.PWNED" not in data_block or "\\u003c/script" in data_block
+        # The literal breakout sequence must be neutralized wherever it appears.
+        assert PAYLOAD not in html
+        # No raw `<` survives in the embedded data itself -- every one is
+        # \u003c-escaped, which also kills `<!--` and `<script` breakout
+        # variants, not just `</`. Scope to the assignment line, not the
+        # trailing JS (which legitimately contains `<` in loop conditions).
+        data_line = html[start + len("var graphData =") : html.index("\n", start)]
+        assert "<" not in data_line
+
+    def test_payload_survives_a_json_round_trip(self, tmp_path):
+        """Escaping must not corrupt the data -- `\\/` decodes back to `/`."""
+        html = _render_graph(tmp_path, PAYLOAD)
+        start = html.index("var graphData =")
+        raw = html[start + len("var graphData =") : html.index("\n", start)].strip()
+        raw = raw.rstrip(";")
+
+        # `<\/` is a valid JSON escape, so this parses and yields the original.
+        assert json.loads(raw)["documents"]["d1"]["text"] == PAYLOAD
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            PAYLOAD,
+            "</SCRIPT ><img src=x onerror=alert(1)>",
+            "comment breakout <!--<script>window.HACKED=1//-->",
+            "bare <script>alert(1)</script> and <b>markup</b>",
+            "quote \" and apostrophe ' and backslash \\",
+            "line sep \u2028 and paragraph sep \u2029 mid-text",
+            "Prince George's County v. O'Brien",
+        ],
+    )
+    def test_hostile_and_awkward_text_round_trips(self, tmp_path, text):
+        html = _render_graph(tmp_path, text)
+        start = html.index("var graphData =")
+        raw = html[start + len("var graphData =") : html.index("\n", start)].strip().rstrip(";")
+
+        assert json.loads(raw)["documents"]["d1"]["text"] == text
+        # Raw U+2028/U+2029 would be an illegal line terminator in older JS.
+        assert "\u2028" not in raw
+        assert "\u2029" not in raw
+
+    def test_escape_helper_is_a_no_op_on_benign_json(self):
+        benign = json.dumps({"text": "Department of Justice, 441 G Street NW"})
+        assert escape_json_for_script(benign) == benign
+
+    def test_graph_html_loads_nothing_from_the_network(self, tmp_path):
+        html = _render_graph(tmp_path, "harmless text")
+        assert not re.findall(r'(?:src|href)\s*=\s*"https?://', html)
+
+
+class TestWebUIIsOffline:
+    """C6 -- `openfoia serve` must make zero external requests."""
+
+    def test_no_external_resources_are_loaded(self):
+        html = get_index_html()
+        loaded = re.findall(r'(?:src|href)\s*=\s*"(https?://[^"]*)"', html)
+        # An <a href> the user must click is fine; a loaded resource is not.
+        anchors = re.findall(r'<a\b[^>]*href="(https?://[^"]*)"', html)
+        assert [u for u in loaded if u not in anchors] == []
+
+    def test_no_cdn_script_tag(self):
+        html = get_index_html()
+        assert "cdn.tailwindcss.com" not in html
+        assert not re.findall(r"<script[^>]*\ssrc\s*=", html)


### PR DESCRIPTION
## What this is

The novel half of an April "v3.3.0" effort, **reconciled onto the v4.0.0 security release** rather than merged blindly. Most of the original branch's security content turned out to be redundant with (or weaker than) the parallel v4.0.0 hardening that landed via #64/#65, so it was dropped. What remains is what v4.0.0 doesn't have.

## What's new (not on `main`)

- **Claude Code plugin** — `.claude-plugin/marketplace.json`, `plugin/**` (manifest, README, four `/foia-*` commands, `skills/openfoia/SKILL.md`). Lets a human install the CLI + an agent copilot that knows every command. Every documented `openfoia …` invocation was validated against the **live v4.0.0 CLI**.
- **`--version` / `-V`** — root CLI callback wired to `openfoia.__version__` (v4.0.0 had none).
- **`openfoia graph … --no-text`** + a plaintext-export warning — graph HTML embeds full document text; this makes omitting it a choice and warns when it's included.
- **`install.sh` asset-name anchor** — v4.0.0 greps `browser_download_url.*${name}` unanchored; once glyph-api ships `.sha256` assets this can match the checksum file as the binary. Now an anchored `grep -Eo` on the exact asset name. Simulated against a release JSON with both assets → selects only the binary.
- **`test_plugin.py`** (plugin drift test) + **`test_security.py`** (graph-escape / offline-UI, adapted to v4.0.0's stricter escape).
- Housekeeping: bump → **4.1.0**, `pyyaml` in `dev`, `CHANGELOG.md`, air-gap web-UI note, untrack generated `test_graph.html`.

## What was deliberately dropped (v4.0.0 does it better)

- Our `server.py` rewrite + 5 bound tests: v4.0.0 achieves the same properties via **HTTP headers** (CSP `default-src 'self'`, `Referer-Policy: no-referrer`, `Cache-Control: no-store`, non-loopback Host rejection) and covers them in `test_security_network.py` / `test_security_injection.py`. Independently verified: no coverage lost.
- Our graph `escape_for_script`: v4.0.0's `escape_json_for_script` escapes `&`,`<`,`>`,U+2028/9 — a strict superset. Kept theirs.
- Our THREAT_MODEL "Known gaps" + crossref-attribution edits: every gap is already fixed in v4.0.0; the correction is already in its text.

## SKILL.md drift caught

v4.0.0 added a top-level `egress-status` command (Tor egress reporting) our skill didn't document — added. No other invocation had drifted.

## Validation

- Offline suite: **281 passed, 20 skipped, 5 failed**. The 5 are pre-existing on pristine `main` — GLiNER/ollama extraction tests that need model downloads / network, blocked by `conftest`. Baseline was `5 failed, 255 passed`; this PR adds **26 passing tests, zero new failures**. (Those 5 pass only on a machine with the models + ollama + network.)
- `ruff check .` clean · `ruff format --check` clean (pre-commit enforced).
- `openfoia --version` → `4.1.0`.
- Hostile-graph render (`</script>…`, `<!--<script>`, entity label `Acme </script> & Co`): no breakout, no raw `<` in the data line, round-trips intact — v4.0.0's escape holds.

## Reviewed

Underlying fixes went through an independent Opus review (both SHIP) before reconciliation; the two riskiest reconciliation decisions (dropped-server-tests coverage, install.sh anchor) were independently re-verified against v4.0.0.

## Related

- Feeds the search-substrate direction in #66 (the plugin/skill is the delivery path for a private-search tool).
- Pairs with glyph-api v0.6.0 (extraction quality jump) — its CI publishes `pdf-extract` binaries + the `.sha256` files this install.sh fix makes safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
