### PR TITLE
fix: clarify empty typed SEC searches

### DIFF
--- a/openfoia/cli.py
+++ b/openfoia/cli.py
@@ -3942,6 +3942,16 @@ def records_search(
     if not result.entities:
         if result.error:
             rprint(f"[red]Search error ({source}): {result.error}[/red]")
+        elif source == "sec" and filing_type:
+            rprint(
+                f"[yellow]{source} returned {result.total_results} total results for '{query}'.[/yellow]"
+            )
+            rprint(f"[dim]Showing 0 of {result.total_results} results.[/dim]")
+            rprint(f"[dim]Applied SEC filing type filter: {filing_type}[/dim]")
+            rprint(
+                "[yellow]SEC EDGAR full-text search can be incomplete for a company or form type; "
+                "0 results is not proof that no filing exists.[/yellow]"
+            )
         else:
             rprint(f"[yellow]No results found for '{query}' on {source}.[/yellow]")
         return

--- a/tests/test_records_search.py
+++ b/tests/test_records_search.py
@@ -1,0 +1,50 @@
+"""Regression tests for public-records search output."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from openfoia.cli import app
+from openfoia.records.base import SearchResult
+
+
+def test_typed_sec_empty_search_reports_scope_and_coverage_limit(monkeypatch):
+    """A zero typed SEC result must not look like proof that no filing exists."""
+
+    class Adapter:
+        async def search(self, query, **kwargs):
+            assert query == "Webull Corp"
+            assert kwargs == {"filing_type": "F-3"}
+            return SearchResult(source="sec", query=query, total_results=0, entities=[])
+
+    monkeypatch.setattr("openfoia.records.get_adapter", lambda source: Adapter())
+
+    result = CliRunner().invoke(
+        app,
+        ["records", "search", "Webull Corp", "--source", "sec", "--type", "F-3"],
+    )
+
+    assert result.exit_code == 0
+    output = " ".join(result.output.lower().split())
+    assert "sec returned 0 total results for 'webull corp'" in output
+    assert "showing 0 of 0 results" in output
+    assert "applied sec filing type filter: f-3" in output
+    assert "0 results is not proof that no filing exists" in output
+
+
+def test_non_sec_empty_search_keeps_existing_message(monkeypatch):
+    """The typed SEC warning must not change other sources' output."""
+
+    class Adapter:
+        async def search(self, query, **kwargs):
+            return SearchResult(source="opencorporates", query=query, total_results=0, entities=[])
+
+    monkeypatch.setattr("openfoia.records.get_adapter", lambda source: Adapter())
+
+    result = CliRunner().invoke(
+        app,
+        ["records", "search", "No Such Company", "--source", "opencorporates"],
+    )
+
+    assert result.exit_code == 0
+    assert "No results found for 'No Such Company' on opencorporates." in result.output


### PR DESCRIPTION
Closes #69

## Summary
- show the source, query, total, displayed count, and supplied form filter when a typed SEC search returns zero results
- explain that the EDGAR full-text index returning zero does not prove no filing exists
- preserve existing output for all untyped and non-SEC empty searches

## Verification
- python -m pytest tests/test_records_search.py tests/test_security_egress_adapters.py tests/test_security_hardening.py -v (50 passed)
- ruff check openfoia tests
- ruff format --check openfoia tests
- git diff --check
- independent review: pass after one scope correction